### PR TITLE
Replace old fisherman getopts dependency

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,1 +1,1 @@
-fisherman/getopts
+jorgebucaran/fishopts


### PR DESCRIPTION
The fishfile of shark still contains the fisherman dependency for getopts, which causes duplicate packages in fisher. This PR fixes this